### PR TITLE
Add resilient and reliable stop mechanism for batch delete feature

### DIFF
--- a/app/api/migration/items/[jobId]/pause/route.ts
+++ b/app/api/migration/items/[jobId]/pause/route.ts
@@ -1,11 +1,12 @@
 /**
  * Item Migration Job Pause API - POST endpoint
- * Requests a graceful pause of an active migration
+ * Requests a graceful pause of an active migration or cleanup job
  */
 
 import { NextRequest, NextResponse } from 'next/server';
 import { pauseMigration } from '@/lib/migration/shutdown-handler';
 import { migrationStateStore } from '@/lib/migration/state-store';
+import { requestCleanupPause } from '@/lib/migration/cleanup/executor';
 
 export const runtime = 'nodejs';
 
@@ -29,30 +30,56 @@ export async function POST(
       );
     }
 
-    // Check if job is in a pausable state
-    if (job.status !== 'in_progress') {
+    // Check if job is in a pausable state (including 'detecting' and 'deleting' for cleanup jobs)
+    const pausableStates = ['in_progress', 'detecting', 'deleting'];
+    if (!pausableStates.includes(job.status)) {
       return NextResponse.json(
         {
           error: 'Cannot pause job',
-          message: `Job is in '${job.status}' state and cannot be paused. Only 'in_progress' jobs can be paused.`,
+          message: `Job is in '${job.status}' state and cannot be paused. Only jobs in 'in_progress', 'detecting', or 'deleting' state can be paused.`,
         },
         { status: 400 }
       );
     }
 
-    // Request graceful pause
-    await pauseMigration(jobId);
+    // Determine job type and request pause accordingly
+    const jobType = job.jobType || 'migration';
 
-    return NextResponse.json(
-      {
-        success: true,
-        message: 'Migration paused successfully',
-        jobId,
-      },
-      { status: 200 }
-    );
+    if (jobType === 'cleanup') {
+      // Request pause for cleanup job
+      const paused = requestCleanupPause(jobId);
+
+      if (!paused) {
+        // Executor not found - job may not be running yet or already completed
+        // Mark as paused anyway for consistency
+        await migrationStateStore.updateJobStatus(jobId, 'paused');
+      }
+
+      return NextResponse.json(
+        {
+          success: true,
+          message: 'Cleanup job pause requested successfully',
+          jobId,
+          jobType: 'cleanup',
+        },
+        { status: 200 }
+      );
+    } else {
+      // Request graceful pause for migration job
+      await pauseMigration(jobId);
+
+      return NextResponse.json(
+        {
+          success: true,
+          message: 'Migration paused successfully',
+          jobId,
+          jobType: 'migration',
+        },
+        { status: 200 }
+      );
+    }
   } catch (error) {
-    console.error('Failed to pause migration:', error);
+    console.error('Failed to pause job:', error);
 
     return NextResponse.json(
       {

--- a/lib/migration/cleanup/service.ts
+++ b/lib/migration/cleanup/service.ts
@@ -182,11 +182,16 @@ export async function getCleanupJobStatus(jobId: string): Promise<CleanupStatusR
 export async function detectDuplicateGroups(
   client: PodioHttpClient,
   appId: number,
-  matchField: string
+  matchField: string,
+  options?: {
+    jobId?: string;
+    onPauseCheck?: () => boolean;
+  }
 ): Promise<DuplicateGroup[]> {
   logger.info('Detecting duplicate groups with streaming', {
     appId,
     matchField,
+    jobId: options?.jobId,
   });
 
   const startTime = Date.now();
@@ -200,6 +205,16 @@ export async function detectDuplicateGroups(
   for await (const batch of streamItems(client, appId, {
     batchSize: 500,
   })) {
+    // Check for pause request before processing batch
+    if (options?.onPauseCheck && options.onPauseCheck()) {
+      logger.info('Pause requested during duplicate detection streaming', {
+        appId,
+        itemsProcessed,
+        jobId: options.jobId,
+      });
+      throw new Error('PAUSE_REQUESTED');
+    }
+
     for (const item of batch) {
       itemsProcessed++;
 


### PR DESCRIPTION
This commit implements a comprehensive pause/stop mechanism for the cleanup (batch delete) feature to allow users to gracefully stop long-running delete operations at any point.

## Changes Made:

### 1. Enhanced Duplicate Detection Streaming (lib/migration/cleanup/service.ts)
- Modified `detectDuplicateGroups()` to accept optional pause checking callback
- Added pause checks before processing each batch during item streaming
- Throws `PAUSE_REQUESTED` error when pause is detected during detection phase

### 2. Enhanced Cleanup Executor (lib/migration/cleanup/executor.ts)
- Added `pauseRequested` flag and `requestPause()` method to CleanupExecutor
- Added `checkPause()` method that throws when pause is requested
- Integrated pause checking into streaming phase via detectDuplicateGroups callback
- Added pause checking between deletion batches for responsive stopping
- Enhanced error handling to catch `PAUSE_REQUESTED` and gracefully mark job as 'paused'

### 3. Created Cleanup Executor Registry (lib/migration/cleanup/executor.ts)
- Implemented `CleanupExecutorRegistry` class to track active cleanup executors
- Added `requestCleanupPause()` exported function for external pause requests
- Automatically registers/unregisters executors in `executeCleanup()` lifecycle

### 4. Updated Pause API Endpoint (app/api/migration/items/[jobId]/pause/route.ts)
- Extended pause endpoint to support both migration and cleanup job types
- Added 'detecting' and 'deleting' states to pausable job states
- Routes cleanup job pause requests to cleanup executor registry
- Provides appropriate responses based on job type

## Benefits:

✅ **Responsive Stopping**: Checks for pause requests during streaming AND between deletion batches
✅ **No Data Loss**: Gracefully completes current batch before stopping
✅ **Proper State Management**: Updates job status to 'paused' when stopped
✅ **Unified API**: Uses same pause endpoint for both migration and cleanup jobs
✅ **Resilient Design**: Handles edge cases like executor not found (job completed/not started)

## Technical Details:

- Pause checks occur:
  1. Before processing each batch during duplicate detection streaming (every ~500 items)
  2. Before each deletion batch (every ~100 items by default)
- Uses error-based flow control with `PAUSE_REQUESTED` error for clean unwinding
- Integrates with existing pause infrastructure while maintaining separation of concerns
- No breaking changes to existing APIs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Pause functionality now supports cleanup operations alongside migration jobs.
  * Extended pause capability across additional job states during the operation lifecycle.
  * Improved state consistency when pausing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->