### PR TITLE
Fix Podio API Rate Limit Handling Bug

### DIFF
--- a/lib/migration/items/batch-processor.ts
+++ b/lib/migration/items/batch-processor.ts
@@ -780,13 +780,15 @@ export class ItemBatchProcessor extends EventEmitter {
     const { appId, logUpdateEvent } = options;
     const hasRateLimitErrors = batchResult.failed.some(failure => this.isRateLimitFailure(failure.error));
 
-    if (!hasRateLimitErrors || batchNum >= batches - 1) {
+    // Only skip if no rate limit errors were found
+    if (!hasRateLimitErrors) {
       return;
     }
 
+    // Always wait for rate limit reset if errors were detected
     const timeUntilReset = tracker.getTimeUntilReset();
     if (timeUntilReset <= 0) {
-      return;
+      return; // Rate limit already reset
     }
 
     const resumeAt = new Date(Date.now() + timeUntilReset);


### PR DESCRIPTION
The handlePostBatchRateLimit() function had a critical bug where it would skip waiting for rate limit resets when processing the last batch. This caused all subsequent API calls to fail with 429 rate limit errors.

Root cause: The condition `if (!hasRateLimitErrors || batchNum >= batches - 1)` would return early on the last batch, preventing the system from pausing.

Fix: Removed the `batchNum >= batches - 1` check so the system now pauses for rate limits regardless of which batch is being processed.

This ensures:
- Rate limit pauses happen on first, middle, or last batch
- System waits for full reset period before resuming
- Migration can continue successfully after rate limit reset

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved rate-limit handling logic to ensure consistent reset behavior when rate-limit errors occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->