### PR TITLE
Optimize Failed Item Storage for Large Migrations

### DIFF
--- a/lib/migration/items/failure-logger.ts
+++ b/lib/migration/items/failure-logger.ts
@@ -1,14 +1,19 @@
 /**
  * Failure Logger - Handles writing/reading failed items to/from log files
  *
- * Uses append-only writes (JSONL format) to avoid O(n²) complexity of
+ * Uses append-only writes (JSONL format) to avoid O(n^2) complexity of
  * rewriting the entire migration state file for each failure.
+ * The base directory can be overridden via MIGRATION_FAILURE_LOG_DIR.
  */
 
-import { promises as fs } from 'fs';
-import path from 'path';
+import { createReadStream, promises as fs } from 'node:fs';
+import readline from 'node:readline';
+import path from 'node:path';
 import { FailedItemDetail } from '../state-store';
 import { logger } from '../logging';
+
+const LOG_ROOT_CONFIG = process.env.MIGRATION_FAILURE_LOG_DIR || 'logs/migrations';
+const DEFAULT_LOG_ROOT = path.resolve(process.cwd(), LOG_ROOT_CONFIG);
 
 /**
  * Failure logger for item migrations
@@ -16,9 +21,10 @@ import { logger } from '../logging';
  */
 export class FailureLogger {
   private baseLogPath: string;
+  private writeQueue = new Map<string, Promise<void>>();
 
-  constructor(baseLogPath = 'logs/migrations') {
-    this.baseLogPath = baseLogPath;
+  constructor(baseLogPath = DEFAULT_LOG_ROOT) {
+    this.baseLogPath = path.resolve(baseLogPath);
   }
 
   /**
@@ -36,20 +42,60 @@ export class FailureLogger {
     await fs.mkdir(logDir, { recursive: true });
   }
 
+  private async enqueueWrite(jobId: string, task: () => Promise<void>): Promise<void> {
+    const previous = this.writeQueue.get(jobId) ?? Promise.resolve();
+    const next = previous.catch((error) => {
+      logger.error('Previous failure log write failed - continuing', {
+        jobId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }).then(task);
+
+    this.writeQueue.set(jobId, next);
+
+    try {
+      await next;
+    } finally {
+      if (this.writeQueue.get(jobId) === next) {
+        this.writeQueue.delete(jobId);
+      }
+    }
+  }
+
+  private parseFailedItem(line: string, jobId: string): FailedItemDetail | null {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      return null;
+    }
+
+    try {
+      const item = JSON.parse(trimmed) as FailedItemDetail;
+      item.firstAttemptAt = new Date(item.firstAttemptAt);
+      item.lastAttemptAt = new Date(item.lastAttemptAt);
+      return item;
+    } catch (parseError) {
+      logger.warn('Failed to parse failed item line', {
+        jobId,
+        line: trimmed,
+        error: parseError instanceof Error ? parseError.message : String(parseError),
+      });
+      return null;
+    }
+  }
+
   /**
    * Write a single failed item to log file (append-only)
    * Uses JSONL format: one JSON object per line
    */
   async logFailedItem(jobId: string, item: FailedItemDetail): Promise<void> {
     try {
-      await this.ensureLogDirectory(jobId);
-      const logPath = this.getFailuresLogPath(jobId);
+      await this.enqueueWrite(jobId, async () => {
+        await this.ensureLogDirectory(jobId);
+        const logPath = this.getFailuresLogPath(jobId);
+        const jsonLine = JSON.stringify(item) + '\n';
 
-      // Serialize to single-line JSON
-      const jsonLine = JSON.stringify(item) + '\n';
-
-      // Append to file (no need to read entire file)
-      await fs.appendFile(logPath, jsonLine, 'utf-8');
+        await fs.appendFile(logPath, jsonLine, { encoding: 'utf8', flag: 'a', mode: 0o640 });
+      });
 
       logger.debug('Logged failed item', {
         jobId,
@@ -67,6 +113,34 @@ export class FailureLogger {
   }
 
   /**
+   * Write multiple failed items to the log in one append
+   */
+  async logFailedItemsBulk(jobId: string, items: FailedItemDetail[]): Promise<void> {
+    if (items.length === 0) {
+      return;
+    }
+
+    try {
+      await this.enqueueWrite(jobId, async () => {
+        await this.ensureLogDirectory(jobId);
+        const logPath = this.getFailuresLogPath(jobId);
+        const jsonLines = items.map(item => JSON.stringify(item)).join('\n') + '\n';
+
+        await fs.appendFile(logPath, jsonLines, { encoding: 'utf8', flag: 'a', mode: 0o640 });
+      });
+
+      logger.debug('Logged failed items in bulk', { jobId, count: items.length });
+    } catch (error) {
+      logger.error('Failed to log failed items in bulk', {
+        jobId,
+        count: items.length,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw error;
+    }
+  }
+
+  /**
    * Read all failed items from log file
    * Used for retry operations and UI display
    */
@@ -76,42 +150,23 @@ export class FailureLogger {
     try {
       const content = await fs.readFile(logPath, 'utf-8');
 
-      // Handle empty file
       if (!content.trim()) {
         return [];
       }
 
-      // Parse JSONL format (one JSON object per line)
       const lines = content.trim().split('\n');
       const items: FailedItemDetail[] = [];
 
       for (const line of lines) {
-        if (line.trim()) {
-          try {
-            const item = JSON.parse(line) as FailedItemDetail;
-            // Convert date strings back to Date objects
-            item.firstAttemptAt = new Date(item.firstAttemptAt);
-            item.lastAttemptAt = new Date(item.lastAttemptAt);
-            items.push(item);
-          } catch (parseError) {
-            logger.warn('Failed to parse failed item line', {
-              jobId,
-              line,
-              error: parseError instanceof Error ? parseError.message : String(parseError),
-            });
-            // Skip corrupted lines
-          }
+        const parsed = this.parseFailedItem(line, jobId);
+        if (parsed) {
+          items.push(parsed);
         }
       }
 
-      logger.debug('Read failed items from log', {
-        jobId,
-        count: items.length,
-      });
-
+      logger.debug('Read failed items from log', { jobId, count: items.length });
       return items;
     } catch (error) {
-      // Handle file not found gracefully (e.g., fresh migration with no failures yet)
       if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
         logger.debug('Failures log not found (no failures yet)', { jobId });
         return [];
@@ -125,29 +180,74 @@ export class FailureLogger {
     }
   }
 
+  async getFailedItemIds(jobId: string): Promise<number[]> {
+    const logPath = this.getFailuresLogPath(jobId);
+    const ids: number[] = [];
+
+    try {
+      const rl = readline.createInterface({
+        input: createReadStream(logPath, { encoding: 'utf8' }),
+        crlfDelay: Infinity,
+      });
+
+      try {
+        for await (const line of rl) {
+          const parsed = this.parseFailedItem(line, jobId);
+          if (parsed && typeof parsed.sourceItemId === 'number') {
+            ids.push(parsed.sourceItemId);
+          }
+        }
+      } finally {
+        rl.close();
+      }
+
+      logger.debug('Loaded failed item IDs', { jobId, count: ids.length });
+      return ids;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        return [];
+      }
+
+      logger.error('Failed to load failed item IDs', {
+        jobId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw error;
+    }
+  }
+
   /**
    * Get failed items count without loading all items
-   * Reads file line count for efficiency
+   * Streams the file to count entries for efficiency
    */
   async getFailedItemCount(jobId: string): Promise<number> {
+    return this.getFailedCount(jobId);
+  }
+
+  async getFailedCount(jobId: string): Promise<number> {
     const logPath = this.getFailuresLogPath(jobId);
 
     try {
-      const content = await fs.readFile(logPath, 'utf-8');
+      const rl = readline.createInterface({
+        input: createReadStream(logPath, { encoding: 'utf8' }),
+        crlfDelay: Infinity,
+      });
 
-      // Handle empty file
-      if (!content.trim()) {
-        return 0;
+      let count = 0;
+
+      try {
+        for await (const line of rl) {
+          if (line.trim()) {
+            count += 1;
+          }
+        }
+      } finally {
+        rl.close();
       }
-
-      // Count non-empty lines
-      const lines = content.trim().split('\n');
-      const count = lines.filter(line => line.trim()).length;
 
       logger.debug('Counted failed items', { jobId, count });
       return count;
     } catch (error) {
-      // Handle file not found gracefully
       if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
         return 0;
       }
@@ -162,23 +262,24 @@ export class FailureLogger {
 
   /**
    * Clear failed items log (for retry operations)
-   * Deletes the log file to start fresh
+   * Truncates the file to preserve handles held by other readers
    */
   async clearFailedItems(jobId: string): Promise<void> {
     const logPath = this.getFailuresLogPath(jobId);
 
     try {
-      await fs.unlink(logPath);
+      await fs.truncate(logPath, 0);
       logger.info('Cleared failed items log', { jobId });
     } catch (error) {
-      // Ignore if file doesn't exist (already clear)
-      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
-        logger.error('Failed to clear failed items log', {
-          jobId,
-          error: error instanceof Error ? error.message : String(error),
-        });
-        throw error;
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        return;
       }
+
+      logger.error('Failed to clear failed items log', {
+        jobId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw error;
     }
   }
 

--- a/lib/migration/items/service.ts
+++ b/lib/migration/items/service.ts
@@ -9,6 +9,7 @@ import { getAppStructureDetailed } from '../../podio/migration';
 import { logger } from '../logging';
 import { isJobActive } from '../job-lifecycle';
 import { failureLogger } from './failure-logger';
+import { maskPII } from '../utils/pii-masking';
 
 /**
  * Field types that are valid for matching
@@ -384,7 +385,7 @@ export async function getItemMigrationJob(
       : undefined,
     failedItems: failedItems.map(item => ({
       sourceItemId: item.sourceItemId,
-      error: item.error,
+      error: maskPII(item.error),
       timestamp: typeof item.lastAttemptAt === 'string'
         ? item.lastAttemptAt
         : item.lastAttemptAt.toISOString(),


### PR DESCRIPTION
…rge migrations

Problem:
- Migration JSON files grew to 4.8MB+ with 9,000+ failures
- O(n²) write complexity: each failure triggered full file reload/rewrite
- Memory exhaustion: Next.js server hit memory threshold at 30K+ items

Solution:
- Store failed item details in append-only JSONL log file (logs/migrations/{jobId}/failures.log)
- Keep only summary counts in migration JSON (total count + by-category breakdown)
- Load failed items from log file only when needed (retry, UI display)

Changes:
1. Created lib/migration/items/failure-logger.ts
   - Append-only writes using JSONL format (one JSON per line)
   - Methods: logFailedItem(), getFailedItems(), clearFailedItems()
   - O(1) write complexity instead of O(n²)

2. Updated lib/migration/state-store.ts
   - Added failedItemsByCategory: Record<ErrorCategory, number> to MigrationProgress
   - Deprecated failedItems array (kept for backward compatibility)
   - Replaced addFailedItem() with incrementFailedItemCount()
   - Maintains total failed count + category breakdown

3. Updated lib/migration/items/item-migrator.ts
   - Replaced all addFailedItem() calls with: * incrementFailedItemCount(jobId, errorCategory) * failureLogger.logFailedItem(jobId, failedItemDetail)
   - 4 locations updated (lines 1398, 1458, 1775, 1798)

4. Updated lib/migration/items/runner.ts
   - Load failed items from log file for retry operations
   - Clear log file before retry (instead of clearing array)
   - Reset failedItemsByCategory counters to zero

5. Updated lib/migration/items/service.ts
   - Load failed items from log file for API responses
   - Use failedItemsByCategory for efficient error statistics
   - Fallback to counting from log file for backward compatibility

6. Updated app/api/migration/items/[jobId]/retry/route.ts
   - Load failed items from log file instead of job.progress.failedItems

Expected outcomes:
- Migration JSON files stay <10KB regardless of failure count
- No more memory threshold errors
- 30,000+ item migrations complete successfully
- Failed item details preserved in log file for retry operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent, append-only failure logs for migration items with bulk and single-item logging.
  * Per-category failure counters added to migration progress; pre-retry snapshot preserved for dashboard display.

* **Improvements**
  * Retries now use persistent logs (cleared on retry) and return 202 for accepted retry requests.
  * Improved structured logging, clearer warnings, and PII masking for error fields in responses.
  * Deprecated per-item add path in favor of incrementing category counts (backward-compatible).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->