### PR TITLE
Fix Date Serialization Bug in Migration Job

### DIFF
--- a/lib/migration/state-store.ts
+++ b/lib/migration/state-store.ts
@@ -328,6 +328,37 @@ export class MigrationStateStore {
         completedAt: step.completedAt ? new Date(step.completedAt) : undefined,
       }));
 
+      // Convert nested date fields in progress object
+      if (job.progress) {
+        // Convert throughput.estimatedCompletionTime
+        if (job.progress.throughput?.estimatedCompletionTime) {
+          job.progress.throughput.estimatedCompletionTime = new Date(job.progress.throughput.estimatedCompletionTime);
+        }
+
+        // Convert preRetrySnapshot.lastUpdate
+        if (job.progress.preRetrySnapshot?.lastUpdate) {
+          job.progress.preRetrySnapshot.lastUpdate = new Date(job.progress.preRetrySnapshot.lastUpdate);
+        }
+
+        // Convert batchCheckpoints dates
+        if (job.progress.batchCheckpoints) {
+          job.progress.batchCheckpoints = job.progress.batchCheckpoints.map(checkpoint => ({
+            ...checkpoint,
+            startedAt: new Date(checkpoint.startedAt),
+            completedAt: checkpoint.completedAt ? new Date(checkpoint.completedAt) : undefined,
+          }));
+        }
+
+        // Convert failedItems dates (deprecated but still present in some jobs)
+        if (job.progress.failedItems) {
+          job.progress.failedItems = job.progress.failedItems.map(item => ({
+            ...item,
+            firstAttemptAt: new Date(item.firstAttemptAt),
+            lastAttemptAt: new Date(item.lastAttemptAt),
+          }));
+        }
+      }
+
       return job;
     } catch (error: unknown) {
       if ((error as NodeJS.ErrnoException).code === 'ENOENT') {


### PR DESCRIPTION
Fixes the date serialization/deserialization bug that caused the 500 Internal Server Error for migration job 648e97f4-b722-4310-b7a6-9ff73d0c7d18.

The getMigrationJob() function was converting some date fields from strings back to Date objects, but was missing several deeply nested date fields:

- job.progress.throughput.estimatedCompletionTime
- job.progress.preRetrySnapshot.lastUpdate
- job.progress.batchCheckpoints[].startedAt
- job.progress.batchCheckpoints[].completedAt
- job.progress.failedItems[].firstAttemptAt (deprecated)
- job.progress.failedItems[].lastAttemptAt (deprecated)

This caused a crash when code tried to call .toISOString() on a string value in lib/migration/items/service.ts:364:

  estimatedCompletionTime: job.progress.throughput.estimatedCompletionTime?.toISOString()

Result: TypeError: estimatedCompletionTime.toISOString is not a function

Now all date fields are properly converted when loading migration jobs from the JSON state files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Fixed date field deserialization in migration job data, ensuring temporal values are properly converted from stored string format across all tracking elements including completion estimates, batch checkpoints, retry attempts, and status timestamps. This restores proper functionality for date-dependent monitoring and reporting operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->