### PR TITLE
fix: Implement rate limit pause tracking in migration statistics

### DIFF
--- a/lib/migration/items/runner.ts
+++ b/lib/migration/items/runner.ts
@@ -227,7 +227,7 @@ export async function runItemMigrationJob(jobId: string): Promise<void> {
           remaining: info.remaining,
           limit: info.limit,
           resumeAt: info.resumeAt.toISOString(),
-          pauseStartTime: info.pauseStartTime,
+          pauseStartTime: info.pauseStartTime.toISOString(),
         });
       },
       onRateLimitResume: async (info) => {


### PR DESCRIPTION
## Summary
Implements the missing rate limit pause tracking that was discovered during testing. Rate limit pauses were being emitted by the batch processor but never recorded in migration statistics.

## Root Cause
The `recordRateLimitPause()` method existed in ThroughputCalculator but was never called because:
- Batch processor emits `rateLimitPause` and `rateLimitResume` events
- No event listeners were wired up to capture these events
- TODO comments acknowledged this gap but it was never implemented

## Changes

### 1. Add Callbacks to MigrationConfig Interface
```typescript
onRateLimitPause?: (info: { remaining: number; limit: number; resumeAt: Date; pauseStartTime: number }) => void | Promise<void>;
onRateLimitResume?: (info: { pauseDurationMs: number }) => void | Promise<void>;
```

### 2. Wire Up Event Listeners (item-migrator.ts)
- Listen to batch processor `rateLimitPause` events
- Record pause start time
- Listen to `rateLimitResume` events  
- Calculate pause duration
- Call config callbacks with timing data

### 3. Implement Callbacks (runner.ts)
- `onRateLimitPause`: Log pause start details
- `onRateLimitResume`: Call `throughputCalculator.recordRateLimitPause(durationMs)`
- Update migration statistics immediately after pause ends

### 4. Update Comments
- Remove TODO comments about tracking rate limiting
- Add explanatory comments about callback-based tracking

## Impact

**Before:**
- `rateLimitPauses`: Always 0 ❌
- `totalRateLimitDelay`: Always 0 ❌
- No visibility into rate limit impact

**After:**
- `rateLimitPauses`: Increments after each pause ✅
- `totalRateLimitDelay`: Tracks cumulative wait time ✅
- Statistics accurately reflect rate limit impact ✅
- Stats update immediately when pause ends ✅

## Testing
When a migration hits a rate limit:
1. During pause: Counter shows previous pauses
2. After pause ends: Counter increments immediately
3. Job stats show accurate pause count and total delay

## Files Changed
- `lib/migration/items/item-migrator.ts` - Add event listeners
- `lib/migration/items/runner.ts` - Pass callbacks, call recorder

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added rate-limit lifecycle hooks to migrations so you can monitor when rate-limit pauses start and end.
  * Hooks provide pause start time, expected resume time, and pause duration so external listeners can track and react.
  * Resumes update throughput tracking and safeguards are in place to prevent callback failures from disrupting migrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->