### PR TITLE
Remove deprecated instrumentationHook from Next.js config

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,9 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  // Enable instrumentation for server-side initialization
-  experimental: {
-    instrumentationHook: true,
-  },
+  // instrumentation.js is now available by default in Next.js 15
 };
 
 export default nextConfig;


### PR DESCRIPTION
…config

The instrumentationHook is no longer needed in Next.js 15 as instrumentation.js is now available by default. This removes the deprecated configuration to eliminate build warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration to rely on default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->